### PR TITLE
RATE-4270 BOA - if xmlns="" 

### DIFF
--- a/src/main/scala/uk/gov/hmrc/akka/xml/StreamHelper.scala
+++ b/src/main/scala/uk/gov/hmrc/akka/xml/StreamHelper.scala
@@ -41,7 +41,7 @@ trait StreamHelper {
   def getCompletedXMLElements(xmlElementsLst: scala.collection.mutable.Set[XMLElement]):
   scala.collection.mutable.Set[XMLElement] = {
     val completedElements = xmlElementsLst.collect {
-      case e if !(e.xPath.nonEmpty && e.value.isEmpty) => e
+      case e if !(e.xPath.nonEmpty && (e.value.isEmpty && e.attributes.isEmpty)) => e
     }
 
     completedElements.foreach({

--- a/src/test/scala/uk/gov/hmrc/akka/xml/XMLParserXMLExtractNamespaceSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/akka/xml/XMLParserXMLExtractNamespaceSpec.scala
@@ -21,6 +21,7 @@ import akka.util.ByteString
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.mock.MockitoSugar
+import org.scalatest.time.{Millis, Seconds, Span}
 
 class XMLParserXMLExtractNamespaceSpec extends FlatSpec
   with Matchers
@@ -30,6 +31,8 @@ class XMLParserXMLExtractNamespaceSpec extends FlatSpec
   with XMLParserFixtures {
 
   val f = fixtures
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(5, Millis))
 
   import f._
 

--- a/src/test/scala/uk/gov/hmrc/akka/xml/XMLParserXmlExtractSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/akka/xml/XMLParserXmlExtractSpec.scala
@@ -404,7 +404,7 @@ class XMLParserXmlExtractSpec extends FlatSpec
     val paths = Seq[XMLInstruction](XMLExtract(Seq("xml"), Map("type" -> "test")))
 
     whenReady(source.runWith(parseToXMLElements(paths))) { r =>
-      r shouldBe Set(XMLElement(Seq("xml"), Map("type" -> "test"), Some("")),
+      r shouldBe Set(XMLElement(Seq("xml"), Map("type" -> "test"), None),
         XMLElement(List(), Map(CompleteChunkStage.STREAM_SIZE -> "66"), Some(CompleteChunkStage.STREAM_SIZE)))
     }
     whenReady(source.runWith(parseToByteString(paths))) { r =>
@@ -418,7 +418,7 @@ class XMLParserXmlExtractSpec extends FlatSpec
     val paths = Seq[XMLInstruction](XMLExtract(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope")))
 
     whenReady(source.runWith(parseToXMLElements(paths))) { r =>
-      r shouldBe Set(XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), Some("")),
+      r shouldBe Set(XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), None),
         XMLElement(List(), Map(CompleteChunkStage.STREAM_SIZE -> "100"), Some(CompleteChunkStage.STREAM_SIZE)))
     }
     whenReady(source.runWith(parseToByteString(paths))) { r =>
@@ -447,7 +447,7 @@ class XMLParserXmlExtractSpec extends FlatSpec
 
     whenReady(source.runWith(parseToXMLElements(paths))) { r =>
       r shouldBe Set(
-        XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), Some("")),
+        XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), None),
         XMLElement(List(), Map(CompleteChunkStage.STREAM_SIZE -> "236"), Some(CompleteChunkStage.STREAM_SIZE))
       )
     }
@@ -469,9 +469,9 @@ class XMLParserXmlExtractSpec extends FlatSpec
 
     whenReady(source.runWith(parseToXMLElements(paths))) { r =>
       r shouldBe Set(
-        XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), Some("")),
+        XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), None),
         XMLElement(List(), Map(CompleteChunkStage.STREAM_SIZE -> "236"), Some(CompleteChunkStage.STREAM_SIZE)),
-        XMLElement(Seq("xml"), Map("schemaLocation" -> "http://www.govtalk.gov.uk/CM/envelope envelope-v2-0-HMRC.xsd"), Some(""))
+        XMLElement(Seq("xml"), Map("schemaLocation" -> "http://www.govtalk.gov.uk/CM/envelope envelope-v2-0-HMRC.xsd"), None)
       )
     }
     whenReady(source.runWith(parseToByteString(paths))) { r =>
@@ -494,9 +494,9 @@ class XMLParserXmlExtractSpec extends FlatSpec
 
     whenReady(source.runWith(parseToXMLElements(paths))) { r =>
       r shouldBe Set(
-        XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), Some("")),
+        XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), None),
         XMLElement(List(), Map(CompleteChunkStage.STREAM_SIZE -> "236"), Some(CompleteChunkStage.STREAM_SIZE)),
-        XMLElement(Seq("xml"), Map("xmlns:xsi" -> "http://www.w3.org/2001/XMLSchema-instance"), Some(""))
+        XMLElement(Seq("xml"), Map("xmlns:xsi" -> "http://www.w3.org/2001/XMLSchema-instance"), None)
       )
     }
 
@@ -520,7 +520,7 @@ class XMLParserXmlExtractSpec extends FlatSpec
 
     whenReady(source.runWith(parseToXMLElements(paths))) { r =>
       r shouldBe Set(
-        XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), Some("")),
+        XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), None),
         XMLElement(List(), Map(CompleteChunkStage.STREAM_SIZE -> "236"), Some(CompleteChunkStage.STREAM_SIZE))
         // We shouldn't see this one - XMLElement(Seq("xml"), Map("xsi:schemaLocation" -> "http://www.govtalk.gov.uk/CM/envelope envelope-v2-0-HMRC.xsd"), Some("")),
         //XMLElement(Seq("xml"), Map("xmlns:xsi" -> "http://www.w3.org/2001/XMLSchema-instance"), Some(""))
@@ -546,9 +546,9 @@ class XMLParserXmlExtractSpec extends FlatSpec
 
     whenReady(source.runWith(parseToXMLElements(paths))) { r =>
       r shouldBe Set(
-        XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), Some("")),
+        XMLElement(Seq("xml"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"), None),
         XMLElement(List(), Map(CompleteChunkStage.STREAM_SIZE -> "236"), Some(CompleteChunkStage.STREAM_SIZE)),
-        XMLElement(Seq("xml"), Map("schemaLocation" -> "http://www.govtalk.gov.uk/CM/envelope envelope-v2-0-HMRC.xsd"), Some(""))
+        XMLElement(Seq("xml"), Map("schemaLocation" -> "http://www.govtalk.gov.uk/CM/envelope envelope-v2-0-HMRC.xsd"), None)
         //XMLElement(Seq("xml"), Map("xmlns:xsi" -> "http://www.w3.org/2001/XMLSchema-instance"), Some(""))
       )
     }
@@ -596,7 +596,7 @@ class XMLParserXmlExtractSpec extends FlatSpec
     val expected = Set(
       XMLElement(List("GovTalkMessage", "Header", "MessageDetails", "Class"), Map(), Some("HMRC-CT-CT600")),
       XMLElement(List(), Map(CompleteChunkStage.STREAM_SIZE -> "939"), Some(CompleteChunkStage.STREAM_SIZE)),
-      XMLElement(List("GovTalkMessage"), Map("xmlns:gt" -> "http://www.govtalk"), Some("")),
+      XMLElement(List("GovTalkMessage"), Map("xmlns:gt" -> "http://www.govtalk"), None),
       XMLElement(List("GovTalkMessage", "Header", "MessageDetails", "Function"), Map(), Some("submit")),
       XMLElement(List("GovTalkMessage", "Header", "MessageDetails", "Qualifier"), Map(), Some("response")),
       XMLElement(List("GovTalkMessage", "Header", "MessageDetails", "CorrelationID"), Map(), Some("12345678"))
@@ -756,5 +756,43 @@ class XMLParserXmlExtractSpec extends FlatSpec
         r shouldBe t
       }
     }
+  }
+
+  it should "extract the namespace envelope from the attribute" in {
+
+    val source = Source(List(ByteString(
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><GovTalkMessage xmlns=\"http://www.govtalk.gov.uk/CM/envelope\"><EnvelopeVersion>2.0</EnvelopeVersion>"), ByteString(
+      "<Header><MessageDetails><Class>HMRC-CT-CT600</Class><Qualifier>request</Qualifier><Function>submit"), ByteString(
+      "</Function><TransactionID></TransactionID><CorrelationID>454545454</CorrelationID><Transformation>"), ByteString(
+      "XML</Transformation><GatewayTest>0</GatewayTest></MessageDetails><SenderDetails><IDAuthentication>"), ByteString(
+      "<SenderID>user1</SenderID><Authentication><Method>clear</Method><Role>principal</Role>"), ByteString(
+      "<Value>pass</Value></Authentication></IDAuthentication></SenderDetails></Header><GovTalkDetails>"), ByteString(
+      "<Keys><Key Type=\"TestKey\">Retry2</Key></Keys> <TargetDetails><Organisation>CapGemini</Organisation>"), ByteString(
+      "</TargetDetails><ChannelRouting><Channel><URI>1192</URI> <Product>HMRC CT600</Product>"), ByteString(
+      "<Version>1.0.1</Version></Channel></ChannelRouting></GovTalkDetails><Body></Body>"), ByteString(
+      "</GovTalkMessage>")))
+
+
+    val paths = Seq[XMLInstruction](
+      XMLExtract(Seq("GovTalkMessage", "Header", "MessageDetails", "Class")),
+      XMLExtract(Seq("GovTalkMessage"), Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"))
+    )
+
+    val expected = Set(
+      XMLElement(List("GovTalkMessage"),Map("xmlns" -> "http://www.govtalk.gov.uk/CM/envelope"),None),
+      XMLElement(List("GovTalkMessage", "Header", "MessageDetails", "Class"), Map(), Some("HMRC-CT-CT600")),
+      XMLElement(List(), Map(CompleteChunkStage.STREAM_SIZE -> "897"), Some(CompleteChunkStage.STREAM_SIZE))
+    )
+
+    whenReady(source.runWith(parseToXMLElements(paths))) { r =>
+      r shouldBe expected
+    }
+
+    whenReady(source.runWith(parseToByteString(paths))) { r =>
+      whenReady(source.toMat(collectByteString)(Keep.right).run()) { t =>
+        r shouldBe t
+      }
+    }
+
   }
 }

--- a/src/test/scala/uk/gov/hmrc/akka/xml/XMLParserXmlValidateSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/akka/xml/XMLParserXmlValidateSpec.scala
@@ -53,6 +53,7 @@ import akka.util.ByteString
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.mock.MockitoSugar
+import org.scalatest.time.{Millis, Seconds, Span}
 import play.api.libs.iteratee.{Enumeratee, Enumerator, Iteratee}
 
 import scala.util.control.NoStackTrace
@@ -68,6 +69,8 @@ class XMLParserXmlValidateSpec extends FlatSpec
   with XMLParserFixtures {
 
   val f = fixtures
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(5, Millis))
 
   import f._
 


### PR DESCRIPTION
fix a situation when the parser wasn't getting to the closing </GovTalkMessage> tag, and so the attribute in the XMLElement was not being updated from None to Some(). In fact we just needed to stop the method getCompletedXMLElements from filtering out XMLElements that had a None for attribute.