### PR TITLE
GG-4845 remove scala 2.11 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,6 @@ lazy val microservice = Project(appName, file("."))
   .settings(
     scalaVersion := "2.12.10",
     libraryDependencies ++= AppDependencies(),
-    crossScalaVersions := Seq("2.11.12", "2.12.10"),
     resolvers := Seq(
       Resolver.bintrayRepo("hmrc", "releases"),
       "typesafe-releases" at "https://repo.typesafe.com/typesafe/releases/"


### PR DESCRIPTION
silencer plugin doesn't support scala 2.11, and the platform will imminently no longer support scala 2.11